### PR TITLE
Fix fsom compiling on mac

### DIFF
--- a/fsom.h
+++ b/fsom.h
@@ -60,7 +60,7 @@ typedef struct  {
 } som_output_layer_t
 __attribute__ ((aligned));
 
-typedef struct  {
+typedef struct somename {
 	som_input_layer_t   *input_layer;
 	som_output_layer_t  *output_layer;
 	double              T_learning_param;


### PR DESCRIPTION
Add name to struct so that it's no longer anonymous. Mac's g++ throws an error for anonymous types.
